### PR TITLE
Updated _toc.yml and _config.yml due to deprecated behaviour

### DIFF
--- a/bempp-book/_config.yml
+++ b/bempp-book/_config.yml
@@ -52,4 +52,7 @@ sphinx:
   extra_extensions          :   # A list of extra extensions to load by Sphinx.
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration
 parse:
-  myst_extended_syntax: true # Extended syntax for Latex in markdown
+  #myst_extended_syntax: true # Extended syntax for Latex in markdown
+  myst_enable_extensions: 
+    - amsmath 
+    - dollarmath

--- a/bempp-book/_toc.yml
+++ b/bempp-book/_toc.yml
@@ -1,33 +1,18 @@
-- file: intro
-
-- part: API Overview
+format: jb-book
+root: intro
+parts:
+- caption: API Overview
   chapters:
-    - file: api/grids
-    - file: api/function_spaces
-    - file: api/grid_functions
-    - file: api/boundary_operators
-    - file: api/solvers
-    - file: api/potential_operators
-- part: A dive into the Bempp core routines
+  - file: api/grids
+  - file: api/function_spaces
+  - file: api/grid_functions
+  - file: api/boundary_operators
+  - file: api/solvers
+  - file: api/potential_operators
+- caption: A dive into the Bempp core routines
   chapters:
-    - file: core/assembling_operators
-
-- part: Mathematical background of boundary integral equations
+  - file: core/assembling_operators
+- caption: Mathematical background of boundary integral equations
   chapters:
-    - file: theory/greens_representation
-    - file: theory/function_spaces
-      #sections:
-      #      - file: theory/sobolev_spaces
-      #- file: theory/discrete_function_spaces
-      #sections:
-      #      - file: theory/dofs
-      #      - file: theory/inf-sup
-      #      - file: theory/projections
-      
-
-
-      
-
-
-
-      
+  - file: theory/greens_representation
+  - file: theory/function_spaces


### PR DESCRIPTION
Hi, 
I'm not sure to which category this pull request would belong. I tried to build the handbook to have it available offline; however, I noticed I could not get it done due to the syntax used in the _toc and config yml's. It turns out that the behavior of some of the tools you used (myst) has changed in these years!

The _toc error was solved by the utils in Jupyter itself:
"The Table of Contents file is malformed: toc is not a mapping: <class 'list'>
You may need to migrate from the old format, using:

jupyter-book toc migrate original_toc_file.yml -o new_toc_file.yml " 


For the _config.yml the proper config looks like this: https://jupyterbook.org/en/stable/customize/config.html

Hope it helps!