### PR TITLE
Fix typo in grid_functions.md

### DIFF
--- a/bempp-book/api/grid_functions.md
+++ b/bempp-book/api/grid_functions.md
@@ -27,7 +27,7 @@ An optional fifth input may be used to pass parameters into the function.
 
 In order for Bempp to assemble a grid function with coefficients of the correct data type,
 these callables must be decorated with either `@bempp.api.real_callable` or
-`@bempp.api.real_callable`.
+`@bempp.api.complex_callable`.
 
 The projection of this callable into a Bempp space can be created with:
 ```python


### PR DESCRIPTION
Fixes a typo in grid_functions that repeated `real_callable` instead of properly indicating. `complex_callable`.